### PR TITLE
feat: added ecr GetAuthorizationToken, for ecr login

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -44,4 +44,12 @@ data "aws_iam_policy_document" "artifact_user" {
       try(aws_ecrpublic_repository.this[each.key].arn, null),
     ])
   }
+
+  statement {
+    sid       = "AllowECRAuthorization" # needed to login to ecr
+    actions   = [
+      "ecr:GetAuthorizationToken"
+    ]
+    resources = ["*"]
+  }
 }


### PR DESCRIPTION
This PR adds `ecr:GetAuthorizationToken` policy to the create IAM user, which will allow the IAM user to login to ECR, but still only push and read from the single allowed repo.